### PR TITLE
fix: set minimum supported version constraint

### DIFF
--- a/modules/k8s/hello_kubecon/versions.tf
+++ b/modules/k8s/hello_kubecon/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     vault = {
       source  = "hashicorp/vault"
-      version = "~> 3.12.0"
+      version = ">= 3.12.0"
     }
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.0"
+      version = ">= 0.10.0"
     }
   }
 }

--- a/modules/k8s/mysql/versions.tf
+++ b/modules/k8s/mysql/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     vault = {
       source  = "hashicorp/vault"
-      version = "~> 3.12.0"
+      version = ">= 3.12.0"
     }
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.0"
+      version = ">= 0.10.0"
     }
   }
 }

--- a/modules/k8s/postgresql/versions.tf
+++ b/modules/k8s/postgresql/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     vault = {
       source  = "hashicorp/vault"
-      version = "~> 3.12.0"
+      version = ">= 3.12.0"
     }
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.0"
+      version = ">= 0.10.0"
     }
   }
 }

--- a/modules/k8s/synapse/versions.tf
+++ b/modules/k8s/synapse/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     vault = {
       source  = "hashicorp/vault"
-      version = "~> 3.12.0"
+      version = ">= 3.12.0"
     }
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.0"
+      version = ">= 0.10.0"
     }
   }
 }

--- a/modules/k8s/wordpress/versions.tf
+++ b/modules/k8s/wordpress/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     vault = {
       source  = "hashicorp/vault"
-      version = "~> 3.12.0"
+      version = ">= 3.12.0"
     }
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.0"
+      version = ">= 0.10.0"
     }
   }
 }

--- a/modules/machine/mysql/versions.tf
+++ b/modules/machine/mysql/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     vault = {
       source  = "hashicorp/vault"
-      version = "~> 3.12.0"
+      version = ">= 3.12.0"
     }
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.0"
+      version = ">= 0.10.0"
     }
   }
 }

--- a/modules/machine/postgresql/versions.tf
+++ b/modules/machine/postgresql/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     vault = {
       source  = "hashicorp/vault"
-      version = "~> 3.12.0"
+      version = ">= 3.12.0"
     }
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.0"
+      version = ">= 0.10.0"
     }
   }
 }


### PR DESCRIPTION
Shared modules should specify the minimum supported version in their constraint field, to avoid clashes with root modules setting more specific version constraints.

https://developer.hashicorp.com/terraform/language/modules/develop/providers#provider-aliases-within-modules

<!--
Thank you for your interest in and contributing to Terraform Modules!
Please, refer to the CONTRIBUTING.md file for guidance and provide some information
about your PR before proceeding.
-->

### Description

<!-- A high level overview of the change -->

### Type

- [x] Fix issue #11 
- [ ] Add module.
- [ ] Change existing module.
- [ ] Other. Please describe bellow.
<!-- Describe type here if you choose Other -->

### How to test
<!-- Provide an example of how to use or test your PR -->
n/a
### Additional context
<!-- Provide any additional context that might be relevant -->
n/a