### PR TITLE
Fixed pgbouncer revision to use ubuntu@22.04

### DIFF
--- a/modules/machine/pgbouncer-ha/variables.tf
+++ b/modules/machine/pgbouncer-ha/variables.tf
@@ -51,13 +51,13 @@ variable "data_integrator_charm_base" {
 variable "pgbouncer_charm_channel" {
   description = "PgBouncer charm channel"
   type        = string
-  default     = "1/edge"
+  default     = "1/candidate"
 }
 
 variable "pgbouncer_charm_revision" {
   description = "PgBouncer charm revision"
   type        = number
-  default     = 184
+  default     = 173
 }
 
 variable "pgbouncer_charm_base" {


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Terraform Modules!
Please, refer to the CONTRIBUTING.md file for guidance and provide some information
about your PR before proceeding.
-->

### Description

The selected default charm revision does not support ubuntu@22.04 which is used by all the other charms.

### Type

- [ X] Fix issue <!-- provide the issue number in format #number like #123 -->
- [ ] Add module.
- [ ] Change existing module.
- [ ] Other. Please describe bellow.
<!-- Describe type here if you choose Other -->

### How to test
<!-- Provide an example of how to use or test your PR -->

### Additional context
<!-- Provide any additional context that might be relevant -->
