### PR TITLE
Changed pgbouncer default version to 203 for the correct ubuntu support

### DIFF
--- a/modules/machine/pgbouncer-ha/variables.tf
+++ b/modules/machine/pgbouncer-ha/variables.tf
@@ -57,7 +57,7 @@ variable "pgbouncer_charm_channel" {
 variable "pgbouncer_charm_revision" {
   description = "PgBouncer charm revision"
   type        = number
-  default     = 184
+  default     = 203
 }
 
 variable "pgbouncer_charm_base" {


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Terraform Modules!
Please, refer to the CONTRIBUTING.md file for guidance and provide some information
about your PR before proceeding.
-->

### Description

Fixes deployment as the latest version on 1/edge for jammy is 203.

### Type

- [X ] Fix issue <!-- provide the issue number in format #number like #123 -->
- [ ] Add module.
- [ ] Change existing module.
- [ ] Other. Please describe bellow.
<!-- Describe type here if you choose Other -->

### How to test
<!-- Provide an example of how to use or test your PR -->

### Additional context
<!-- Provide any additional context that might be relevant -->
