### PR TITLE
feat(synapse): Add synapse LP modules

### DIFF
--- a/modules/k8s/synapse-ha/README.md
+++ b/modules/k8s/synapse-ha/README.md
@@ -1,0 +1,4 @@
+== Synapse Module ==
+
+Re-usable Synapse deployment, exposing variables for things that might need to
+be different between different environments.

--- a/modules/k8s/synapse-ha/main.tf
+++ b/modules/k8s/synapse-ha/main.tf
@@ -1,0 +1,164 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.10.1"
+    }
+  }
+}
+
+resource "juju_model" "synapse" {
+  name = var.juju_model_name
+  config = {
+    juju-http-proxy  = "${var.proxy_scheme}://%{if var.proxy_user != "" && var.proxy_pass != ""}${var.proxy_user}:${var.proxy_pass}@%{endif}${var.proxy_hostname}:${var.proxy_port}"
+    juju-https-proxy = "${var.proxy_scheme}://%{if var.proxy_user != "" && var.proxy_pass != ""}${var.proxy_user}:${var.proxy_pass}@%{endif}${var.proxy_hostname}:${var.proxy_port}"
+    juju-no-proxy    = "127.0.0.1,localhost,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.canonical.com,.launchpad.net,.internal,.jujucharms.com,.ubuntu.com"
+  }
+  constraints = "root-disk-source=volume"
+  cloud {
+    name   = var.cloud_name
+    region = "default"
+  }
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "juju_application" "synapse" {
+  name  = var.synapse_application_name
+  model = var.juju_model_name
+  trust = true
+
+  charm {
+    name     = "synapse"
+    channel  = var.synapse_charm_channel
+    revision = var.synapse_charm_revision
+    series   = var.synapse_charm_series
+  }
+
+  config = {
+    server_name                        = var.synapse_server_name
+    enable_mjolnir                     = var.synapse_enable_mjolnir
+    public_baseurl                     = var.synapse_public_baseurl
+    notif_from                         = var.synapse_notif_from
+    allow_public_rooms_over_federation = var.allow_public_rooms_over_federation
+    backup_passphrase                  = var.synapse_backup_passphrase
+    enable_irc_bridge                  = var.synapse_enable_irc_bridge
+    irc_bridge_admins                  = var.synapse_irc_bridge_admins
+  }
+
+  units = var.synapse_units
+}
+
+resource "juju_application" "nginx_ingress_integrator" {
+  name  = "nginx-ingress-integrator"
+  model = var.juju_model_name
+  trust = true
+
+  charm {
+    name     = "nginx-ingress-integrator"
+    channel  = var.nginx_ingress_integrator_charm_channel
+    revision = var.nginx_ingress_integrator_charm_revision
+  }
+
+  config = {
+    service-hostname = var.synapse_nginx_ingress_integrator_charm_service_hostname
+    tls-secret-name  = var.nginx_ingress_integrator_charm_tls_secret_name
+  }
+
+  units = 1
+}
+
+resource "juju_integration" "synapse_nginx_ingress_integrator" {
+  model = var.juju_model_name
+
+  application {
+    name     = var.synapse_application_name
+    endpoint = "nginx-route"
+  }
+
+  application {
+    name     = juju_application.nginx_ingress_integrator.name
+    endpoint = "nginx-route"
+  }
+}
+
+resource "juju_application" "smtp_integrator" {
+  name  = "smtp-integrator"
+  model = var.juju_model_name
+
+  charm {
+    name     = "smtp-integrator"
+    channel  = var.smtp_charm_channel
+    revision = var.smtp_charm_revision
+    series   = var.smtp_charm_series
+  }
+
+  config = {
+    auth_type          = "plain"
+    transport_security = "tls"
+    host               = var.smtp_host
+    port               = var.smtp_port
+    user               = var.smtp_user
+    password           = var.smtp_pass
+  }
+  units = 1
+}
+
+resource "juju_integration" "synapse_smtp" {
+  model = var.juju_model_name
+
+  application {
+    name     = juju_application.synapse.name
+    endpoint = "smtp"
+  }
+
+  application {
+    name     = juju_application.smtp_integrator.name
+    endpoint = "smtp-legacy"
+  }
+}
+
+resource "juju_integration" "synapse_saml_integrator" {
+  count = var.saml_integrator_offer_url != "" ? 1 : 0
+  model = var.juju_model_name
+
+  application {
+    name     = var.synapse_application_name
+    endpoint = "saml"
+  }
+
+  application {
+    offer_url = var.saml_integrator_offer_url
+  }
+}
+
+resource "juju_integration" "grafana_dashboard" {
+  count = var.grafana_dashboard_offer_url != "" ? 1 : 0
+  model = var.juju_model_name
+
+  application {
+    name     = var.synapse_application_name
+    endpoint = "grafana-dashboard"
+  }
+
+  application {
+    offer_url = var.grafana_dashboard_offer_url
+  }
+}
+
+resource "juju_integration" "prometheus_scrape" {
+  count = var.prometheus_scrape_offer_url != "" ? 1 : 0
+  model = var.juju_model_name
+
+  application {
+    name     = var.synapse_application_name
+    endpoint = "metrics-endpoint"
+  }
+
+  application {
+    offer_url = var.prometheus_scrape_offer_url
+  }
+}
+

--- a/modules/k8s/synapse-ha/variables.tf
+++ b/modules/k8s/synapse-ha/variables.tf
@@ -1,0 +1,195 @@
+variable "synapse_application_name" {
+  description = "Synapse application name"
+  type        = string
+  default     = "synapse"
+}
+
+variable "synapse_charm_channel" {
+  description = "Synapse charm channel"
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "synapse_charm_revision" {
+  description = "Synapse charm revision"
+  type        = number
+}
+
+variable "synapse_charm_series" {
+  description = "Synapse charm series"
+  type        = string
+  default     = "jammy"
+}
+
+variable "synapse_server_name" {
+  description = "Synapse server name. Unrelated to NGINX service_hostname."
+  type        = string
+}
+
+variable "synapse_enable_mjolnir" {
+  description = "Configures whether to enable Mjolnir - moderation tool for Matrix."
+  type        = bool
+  default     = true
+}
+
+variable "synapse_enable_irc_bridge" {
+  description = "Configures whether to enable IRC Bridge - The IRC bridging service."
+  type        = bool
+  default     = false
+}
+
+variable "synapse_irc_bridge_admins" {
+  description = "Configures users who will be allowed to administrate the IRC Bridge."
+  type        = string
+}
+
+variable "synapse_public_baseurl" {
+  description = "The public-facing base URL that clients use to access this Homeserver."
+  type        = string
+}
+
+variable "synapse_notif_from" {
+  description = "Defines the \"From\" address to use when sending emails."
+  type        = string
+}
+
+variable "synapse_units" {
+  description = "Synapse number of units. Default: 1."
+  type        = number
+  default     = 1
+}
+
+variable "synapse_backup_passphrase" {
+  description = "Defines the passphrase to use to encrypt backups."
+  type        = string
+  sensitive   = true
+  # An empty string will not allow creating or restoring backups.
+  # It cannot be set to null (see https://github.com/juju/terraform-provider-juju/issues/394)
+  default = ""
+}
+
+variable "juju_model_name" {
+  description = "Juju model name"
+  type        = string
+}
+
+variable "synapse_nginx_ingress_integrator_charm_service_hostname" {
+  description = "Synapse Nginx ingress integrator service hostname"
+  type        = string
+}
+
+variable "nginx_ingress_integrator_charm_channel" {
+  description = "Nginx ingress integrator charm channel"
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "nginx_ingress_integrator_charm_revision" {
+  description = "Nginx ingress integrator charm revision"
+  type        = number
+}
+
+variable "nginx_ingress_integrator_charm_tls_secret_name" {
+  description = "Nginx ingress integrator TLS secret name"
+  type        = string
+}
+
+variable "grafana_dashboard_offer_url" {
+  description = "Grafana dashboard offer URL"
+  type        = string
+  default     = ""
+}
+
+variable "prometheus_scrape_offer_url" {
+  description = "Prometheus scrape dashboard offer URL"
+  type        = string
+  default     = ""
+}
+
+variable "saml_integrator_offer_url" {
+  description = "SAML Integrator offer URL"
+  type        = string
+  default     = ""
+}
+
+variable "cloud_name" {
+  description = "K8S cluster name"
+  type        = string
+}
+
+variable "smtp_charm_channel" {
+  description = "smtp-integrator charm channel"
+  type        = string
+}
+
+variable "smtp_charm_revision" {
+  description = "smtp-integrator charm revision"
+  type        = number
+}
+
+variable "smtp_charm_series" {
+  description = "smtp-integrator charm series"
+  type        = string
+  default     = "jammy"
+}
+
+variable "smtp_host" {
+  description = "The hostname of the SMTP host used for sending emails."
+  type        = string
+  default     = "smtp-services.canonical.com"
+}
+
+variable "smtp_pass" {
+  description = "The password if the SMTP server requires authentication."
+  type        = string
+  sensitive   = true
+}
+
+variable "smtp_port" {
+  description = "The port of the SMTP server used for sending emails."
+  type        = number
+  default     = 465
+}
+
+variable "smtp_user" {
+  description = "The username if the SMTP server requires authentication."
+  type        = string
+}
+
+variable "proxy_pass" {
+  description = "The password if the proxy requires authentication."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "proxy_user" {
+  description = "The username if the proxy requires authentication."
+  type        = string
+  default     = ""
+}
+
+variable "proxy_scheme" {
+  description = "Scheme (either http or https) to use for the proxy."
+  type        = string
+  default     = "http"
+}
+
+variable "proxy_port" {
+  description = "Port the proxy server."
+  type        = number
+  default     = 3128
+}
+
+variable "proxy_hostname" {
+  description = "Hostname of the proxy server."
+  type        = string
+  default     = "squid.internal"
+}
+
+variable "allow_public_rooms_over_federation" {
+  description = "Allows any other homeserver to fetch the server's public rooms directory via federation."
+  type        = bool
+  default     = false
+}
+

--- a/modules/machine/postgresql-synapse/main.tf
+++ b/modules/machine/postgresql-synapse/main.tf
@@ -1,0 +1,88 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.8"
+    }
+  }
+}
+
+resource "juju_application" "backups_s3_integrator" {
+  name  = "postgresql-backups-s3-integrator"
+  model = var.juju_model_name
+  trust = true
+
+  charm {
+    name     = "s3-integrator"
+    channel  = "latest/stable"
+    series   = "jammy"
+    revision = 13
+  }
+
+  config = {
+    endpoint     = var.postgresql_backup_endpoint
+    bucket       = var.postgresql_backup_bucket_name
+    path         = var.postgresql_backup_path
+    region       = var.postgresql_backup_region
+    s3-uri-style = "path"
+  }
+
+  units = 1
+
+  provisioner "local-exec" {
+    # There's currently no way to wait for the charm to be idle, hence the sleep
+    # https://github.com/juju/terraform-provider-juju/issues/202
+    command = "sleep 180;$([ $(juju version | cut -d. -f1) = '3' ] && echo 'juju run' || echo 'juju run-action') ${self.name}/leader sync-s3-credentials access-key=${var.postgresql_backup_access_key} secret-key=${var.postgresql_backup_secret_key}"
+  }
+}
+
+resource "juju_application" "postgresql" {
+  name  = var.postgresql_application_name
+  model = var.juju_model_name
+  trust = true
+
+  charm {
+    name     = "postgresql"
+    channel  = var.postgresql_charm_channel
+    revision = var.postgresql_charm_revision
+    series   = var.postgresql_charm_series
+  }
+
+  expose {}
+
+  units = var.postgresql_charm_units
+  config = {
+    plugin_hstore_enable  = true
+    plugin_pg_trgm_enable = true
+  }
+
+  constraints = var.postgresql_charm_constraints
+}
+
+resource "juju_integration" "s3_integrator_postgresql_k8s" {
+  model = var.juju_model_name
+
+  application {
+    name = juju_application.backups_s3_integrator.name
+  }
+
+  application {
+    name = juju_application.postgresql.name
+  }
+}
+
+resource "juju_offer" "postgresql-juju-offer" {
+  model            = var.juju_model_name
+  application_name = juju_application.postgresql.name
+  endpoint         = "database"
+}
+
+module "subordinates" {
+  # tflint-ignore: terraform_module_pinned_source
+  source                 = "git::ssh://git.launchpad.net/canonical-terraform-modules//subordinates?depth=1&ref=v3.0"
+  juju_model             = var.juju_model_name
+  applications_to_relate = [juju_application.postgresql.name, juju_application.backups_s3_integrator.name]
+  subordinate_series     = "jammy"
+  include_telegraf       = false
+}

--- a/modules/machine/postgresql-synapse/outputs.tf
+++ b/modules/machine/postgresql-synapse/outputs.tf
@@ -1,0 +1,3 @@
+output "application_name" {
+  value = juju_application.postgresql.name
+}

--- a/modules/machine/postgresql-synapse/variables.tf
+++ b/modules/machine/postgresql-synapse/variables.tf
@@ -1,0 +1,68 @@
+variable "juju_model_name" {
+  description = "Juju model name"
+  type        = string
+}
+
+variable "postgresql_application_name" {
+  description = "Postgresql application name"
+  type        = string
+  default     = "postgresql-k8s"
+}
+
+variable "postgresql_charm_channel" {
+  description = "Postgresql charm channel"
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "postgresql_charm_revision" {
+  description = "Postgresql charm revision"
+  type        = number
+}
+
+variable "postgresql_charm_series" {
+  description = "Postgresql charm series"
+  type        = string
+}
+
+variable "postgresql_charm_units" {
+  description = "Potgresql charm units number"
+  type        = number
+}
+
+variable "postgresql_backup_endpoint" {
+  description = "Postgresql backup bucket endpoint"
+  type        = string
+}
+
+variable "postgresql_backup_path" {
+  description = "Postgresql backup bucket path"
+  type        = string
+}
+
+variable "postgresql_backup_bucket_name" {
+  description = "Postgresql backup bucket name"
+  type        = string
+}
+
+variable "postgresql_backup_region" {
+  description = "Postgresql backup bucket region"
+  type        = string
+}
+
+variable "postgresql_backup_access_key" {
+  description = "Postgresql backup bucket access key"
+  type        = string
+  sensitive   = true
+}
+
+variable "postgresql_backup_secret_key" {
+  description = "Postgresql backup bucket secret key"
+  type        = string
+  sensitive   = true
+}
+
+variable "postgresql_charm_constraints" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Terraform Modules!
Please, refer to the CONTRIBUTING.md file for guidance and provide some information
about your PR before proceeding.
-->

### Description

<!-- A high level overview of the change -->

Adds two modules for Synapse - the application and the db.

Note that these are different than the existing modules in this repo - the existing synapse one relies on a psql k8s charm explicitly; the existing psql machine charm requires telegraf explicitly and doesn't have subordinates.

### Type

- [ ] Fix issue <!-- provide the issue number in format #number like #123 -->
- [X ] Add module.
- [ ] Change existing module.
- [ ] Other. Please describe bellow.
<!-- Describe type here if you choose Other -->

### How to test
<!-- Provide an example of how to use or test your PR -->

These will be used by the Synapse deployments (they are already to an extent, this is a migration from Launchpad).

### Additional context
<!-- Provide any additional context that might be relevant -->
