### PR TITLE
DPE-5123 MySQL HA modules

### DIFF
--- a/modules/k8s/mysql-ha/main.tf
+++ b/modules/k8s/mysql-ha/main.tf
@@ -39,6 +39,10 @@ resource "juju_application" "mysql" {
     base     = var.mysql_charm_base
   }
 
+  storage_directives = {
+    database = var.mysql_storage_size
+  }
+
   units       = var.mysql_charm_units
   constraints = var.mysql_charm_constraints
 }

--- a/modules/k8s/mysql-ha/main.tf
+++ b/modules/k8s/mysql-ha/main.tf
@@ -1,0 +1,92 @@
+resource "juju_application" "backups_s3_integrator" {
+  name  = "backups-s3-integrator"
+  model = var.juju_model_name
+  trust = true
+
+  charm {
+    name     = "s3-integrator"
+    channel  = var.s3_integrator_charm_channel
+    base     = var.s3_integrator_charm_base
+    revision = var.s3_integrator_charm_revision
+  }
+
+  config = {
+    endpoint     = var.mysql_backup_endpoint
+    bucket       = var.mysql_backup_bucket_name
+    path         = var.juju_model_name
+    region       = var.mysql_backup_region
+    s3-uri-style = "path"
+  }
+
+  units = 1
+
+  provisioner "local-exec" {
+    # There's currently no way to wait for the charm to be idle, hence the wait-for
+    # https://github.com/juju/terraform-provider-juju/issues/202
+    command = "juju wait-for application ${self.name} --query='name==\"${self.name}\" && status==\"blocked\"'; $([ $(juju version | cut -d. -f1) = '3' ] && echo 'juju run' || echo 'juju run-action') ${self.name}/leader sync-s3-credentials access-key=${var.mysql_backup_access_key} secret-key=${var.mysql_backup_secret_key}"
+  }
+}
+
+resource "juju_application" "mysql" {
+  name  = "mysql"
+  model = var.juju_model_name
+  trust = true
+
+  charm {
+    name     = "mysql-k8s"
+    channel  = var.mysql_charm_channel
+    revision = var.mysql_charm_revision
+    base     = var.mysql_charm_base
+  }
+
+  units       = var.mysql_charm_units
+  constraints = var.mysql_charm_constraints
+}
+
+resource "juju_integration" "s3_integrator_mysql" {
+  model = var.juju_model_name
+
+  application {
+    name = juju_application.backups_s3_integrator.name
+  }
+
+  application {
+    name = juju_application.mysql.name
+  }
+}
+
+resource "juju_offer" "mysql_juju_offer" {
+  model            = var.juju_model_name
+  application_name = juju_application.mysql.name
+  endpoint         = "database"
+}
+
+resource "juju_application" "self_signed_certificates" {
+  count = var.enable_tls ? 1 : 0
+  name  = "self-signed-certificates"
+  model = var.juju_model_name
+
+  charm {
+    name     = "self-signed-certificates"
+    channel  = var.self_signed_certificates_charm_channel
+    revision = var.self_signed_certificates_charm_revision
+  }
+
+  config = {
+    ca-common-name = "${var.juju_model_name} CA"
+  }
+
+  units = 1
+}
+
+resource "juju_integration" "mysql_self_signed_certificates" {
+  count = var.enable_tls ? 1 : 0
+  model = var.juju_model_name
+
+  application {
+    name = juju_application.mysql.name
+  }
+  application {
+    name = juju_application.self_signed_certificates[0].name
+  }
+}

--- a/modules/k8s/mysql-ha/main.tf
+++ b/modules/k8s/mysql-ha/main.tf
@@ -39,6 +39,8 @@ resource "juju_application" "mysql" {
     base     = var.mysql_charm_base
   }
 
+  config = var.mysql_charm_config
+
   storage_directives = {
     database = var.mysql_storage_size
   }
@@ -63,6 +65,37 @@ resource "juju_offer" "mysql_juju_offer" {
   model            = var.juju_model_name
   application_name = juju_application.mysql.name
   endpoint         = "database"
+}
+
+resource "juju_application" "mysql_router" {
+  count = var.data_integrator_enabled ? 1 : 0
+  name  = "mysql-router"
+  model = var.juju_model_name
+  trust = true
+
+  charm {
+    name     = "mysql-router-k8s"
+    channel  = var.mysql_router_charm_channel
+    revision = var.mysql_router_charm_revision
+  }
+}
+
+resource "juju_application" "data_integrator" {
+  count = var.data_integrator_enabled ? 1 : 0
+  name  = "data-integrator"
+  model = var.juju_model_name
+
+  charm {
+    name     = "data-integrator"
+    channel  = var.data_integrator_charm_channel
+    revision = var.data_integrator_charm_revision
+  }
+
+  config = {
+    database-name = var.data_integrator_database_name
+  }
+
+  units = 1
 }
 
 resource "juju_application" "self_signed_certificates" {
@@ -92,5 +125,33 @@ resource "juju_integration" "mysql_self_signed_certificates" {
   }
   application {
     name = juju_application.self_signed_certificates[0].name
+  }
+}
+
+resource "juju_integration" "mysql_mysql_router" {
+  count = var.data_integrator_enabled ? 1 : 0
+  model = var.juju_model_name
+
+  application {
+    name     = juju_application.mysql.name
+    endpoint = "database"
+  }
+  application {
+    name     = juju_application.mysql_router[0].name
+    endpoint = "backend-database"
+  }
+}
+
+resource "juju_integration" "mysql_router_data_integrator" {
+  count = var.data_integrator_enabled ? 1 : 0
+  model = var.juju_model_name
+
+  application {
+    name     = juju_application.mysql_router[0].name
+    endpoint = "database"
+  }
+  application {
+    name     = juju_application.data_integrator[0].name
+    endpoint = "mysql"
   }
 }

--- a/modules/k8s/mysql-ha/outputs.tf
+++ b/modules/k8s/mysql-ha/outputs.tf
@@ -1,0 +1,3 @@
+output "application_name" {
+  value = juju_application.mysql.name
+}

--- a/modules/k8s/mysql-ha/variables.tf
+++ b/modules/k8s/mysql-ha/variables.tf
@@ -67,7 +67,54 @@ variable "mysql_storage_size" {
   default     = "10G"
 }
 
+variable "mysql_charm_config" {
+  description = "MySQL charm configuration"
+  type        = map(string)
+  default     = {}
+}
+
+variable "mysql_router_charm_channel" {
+  description = "MySQL router charm channel"
+  type        = string
+  default     = "8.0/stable"
+}
+
+variable "mysql_router_charm_revision" {
+  description = "MySQL router charm revision"
+  type        = number
+  default     = 155
+}
+
+variable "data_integrator_enabled" {
+  description = "Enable data integrator for external connectivity"
+  type        = bool
+  default     = false
+}
+
+variable "data_integrator_charm_channel" {
+  description = "Data integrator charm channel"
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "data_integrator_charm_revision" {
+  description = "Data integrator charm revision"
+  type        = number
+  default     = 41
+}
+
+variable "data_integrator_database_name" {
+  description = "Data integrator database name"
+  type        = string
+  default     = ""
+  validation {
+    condition     = var.data_integrator_enabled == false || var.data_integrator_database_name != ""
+    error_message = "data_integrator_database_name must be set if data_integrator_enabled is true."
+  }
+}
+
 variable "enable_tls" {
+  description = "Enable/enforce TLS through self-signed certificates"
   type    = bool
   default = true
 }

--- a/modules/k8s/mysql-ha/variables.tf
+++ b/modules/k8s/mysql-ha/variables.tf
@@ -61,6 +61,12 @@ variable "mysql_charm_constraints" {
   default = ""
 }
 
+variable "mysql_storage_size" {
+  description = "MySQL storage size"
+  type        = string
+  default     = "10G"
+}
+
 variable "enable_tls" {
   type    = bool
   default = true

--- a/modules/k8s/mysql-ha/variables.tf
+++ b/modules/k8s/mysql-ha/variables.tf
@@ -1,0 +1,97 @@
+variable "juju_model_name" {
+  description = "Juju model name"
+  type        = string
+}
+
+variable "mysql_charm_channel" {
+  description = "MySQL K8s charm channel"
+  type        = string
+  default     = "8.0/edge"
+}
+
+variable "mysql_charm_revision" {
+  description = "MySQL K8s charm revision"
+  type        = number
+  default     = 197
+}
+
+variable "mysql_charm_base" {
+  description = "MySQL K8s charm base"
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "mysql_charm_units" {
+  description = "MySQL K8s charm units number"
+  type        = number
+  default     = 3
+}
+
+variable "mysql_backup_endpoint" {
+  description = "MySQL K8s backup bucket endpoint"
+  type        = string
+}
+
+variable "mysql_backup_bucket_name" {
+  description = "MySQL K8s backup bucket name"
+  type        = string
+}
+
+variable "mysql_backup_region" {
+  description = "MySQL K8s backup bucket region"
+  type        = string
+}
+
+variable "mysql_backup_access_key" {
+  description = "MySQL K8s backup bucket access key"
+  type        = string
+}
+
+variable "mysql_backup_secret_key" {
+  description = "MySQL K8s backup bucket secret key"
+  type        = string
+  sensitive   = true
+}
+
+variable "mysql_charm_constraints" {
+  # provider sets inconsistent constraint result with architecture (e.g. `arch=amd64`)
+  # user of the module needs to set the variable to the current arch value.
+  # See: https://github.com/juju/terraform-provider-juju/issues/344
+  type    = string
+  default = ""
+}
+
+variable "enable_tls" {
+  type    = bool
+  default = true
+}
+
+variable "s3_integrator_charm_channel" {
+  description = "S3 integrator charm channel"
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "s3_integrator_charm_revision" {
+  description = "S3 integrator charm revision"
+  type        = number
+  default     = 32
+}
+
+variable "s3_integrator_charm_base" {
+  description = "S3 integrator charm base"
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "self_signed_certificates_charm_channel" {
+  description = "Self Signed Certificates Operator charm channel"
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "self_signed_certificates_charm_revision" {
+  description = "Self Signed Operator charm revision"
+  type        = number
+  default     = 155
+}

--- a/modules/k8s/mysql-ha/versions.tf
+++ b/modules/k8s/mysql-ha/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.13.0"
+      version = ">= 0.14.0"
     }
   }
 }

--- a/modules/k8s/mysql-ha/versions.tf
+++ b/modules/k8s/mysql-ha/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.13.0"
+    }
+  }
+}

--- a/modules/machine/mysql-ha/main.tf
+++ b/modules/machine/mysql-ha/main.tf
@@ -39,6 +39,10 @@ resource "juju_application" "mysql" {
     base     = var.mysql_charm_base
   }
 
+  storage_directives = {
+    database = var.mysql_storage_size
+  }
+
   units       = var.mysql_charm_units
   constraints = var.mysql_charm_constraints
 }

--- a/modules/machine/mysql-ha/main.tf
+++ b/modules/machine/mysql-ha/main.tf
@@ -1,0 +1,92 @@
+resource "juju_application" "backups_s3_integrator" {
+  name  = "backups-s3-integrator"
+  model = var.juju_model_name
+  trust = true
+
+  charm {
+    name     = "s3-integrator"
+    channel  = var.s3_integrator_charm_channel
+    base     = var.s3_integrator_charm_base
+    revision = var.s3_integrator_charm_revision
+  }
+
+  config = {
+    endpoint     = var.mysql_backup_endpoint
+    bucket       = var.mysql_backup_bucket_name
+    path         = var.juju_model_name
+    region       = var.mysql_backup_region
+    s3-uri-style = "path"
+  }
+
+  units = 1
+
+  provisioner "local-exec" {
+    # There's currently no way to wait for the charm to be idle, hence the wait-for
+    # https://github.com/juju/terraform-provider-juju/issues/202
+    command = "juju wait-for application ${self.name} --query='name==\"${self.name}\" && status==\"blocked\"'; $([ $(juju version | cut -d. -f1) = '3' ] && echo 'juju run' || echo 'juju run-action') ${self.name}/leader sync-s3-credentials access-key=${var.mysql_backup_access_key} secret-key=${var.mysql_backup_secret_key}"
+  }
+}
+
+resource "juju_application" "mysql" {
+  name  = "mysql"
+  model = var.juju_model_name
+  trust = true
+
+  charm {
+    name     = "mysql"
+    channel  = var.mysql_charm_channel
+    revision = var.mysql_charm_revision
+    base     = var.mysql_charm_base
+  }
+
+  units       = var.mysql_charm_units
+  constraints = var.mysql_charm_constraints
+}
+
+resource "juju_integration" "s3_integrator_mysql" {
+  model = var.juju_model_name
+
+  application {
+    name = juju_application.backups_s3_integrator.name
+  }
+
+  application {
+    name = juju_application.mysql.name
+  }
+}
+
+resource "juju_offer" "mysql_juju_offer" {
+  model            = var.juju_model_name
+  application_name = juju_application.mysql.name
+  endpoint         = "database"
+}
+
+resource "juju_application" "self_signed_certificates" {
+  count = var.enable_tls ? 1 : 0
+  name  = "self-signed-certificates"
+  model = var.juju_model_name
+
+  charm {
+    name     = "self-signed-certificates"
+    channel  = var.self_signed_certificates_charm_channel
+    revision = var.self_signed_certificates_charm_revision
+  }
+
+  config = {
+    ca-common-name = "${var.juju_model_name} CA"
+  }
+
+  units = 1
+}
+
+resource "juju_integration" "mysql_self_signed_certificates" {
+  count = var.enable_tls ? 1 : 0
+  model = var.juju_model_name
+
+  application {
+    name = juju_application.mysql.name
+  }
+  application {
+    name = juju_application.self_signed_certificates[0].name
+  }
+}

--- a/modules/machine/mysql-ha/outputs.tf
+++ b/modules/machine/mysql-ha/outputs.tf
@@ -1,0 +1,3 @@
+output "application_name" {
+  value = juju_application.mysql.name
+}

--- a/modules/machine/mysql-ha/variables.tf
+++ b/modules/machine/mysql-ha/variables.tf
@@ -1,0 +1,97 @@
+variable "juju_model_name" {
+  description = "Juju model name"
+  type        = string
+}
+
+variable "mysql_charm_channel" {
+  description = "MySQL charm channel"
+  type        = string
+  default     = "8.0/stable"
+}
+
+variable "mysql_charm_revision" {
+  description = "MySQL charm revision"
+  type        = number
+  default     = 240
+}
+
+variable "mysql_charm_base" {
+  description = "MySQL charm base"
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "mysql_charm_units" {
+  description = "MySQL charm units number"
+  type        = number
+  default     = 3
+}
+
+variable "mysql_backup_endpoint" {
+  description = "MySQL backup bucket endpoint"
+  type        = string
+}
+
+variable "mysql_backup_bucket_name" {
+  description = "MySQL backup bucket name"
+  type        = string
+}
+
+variable "mysql_backup_region" {
+  description = "MySQL backup bucket region"
+  type        = string
+}
+
+variable "mysql_backup_access_key" {
+  description = "MySQL backup bucket access key"
+  type        = string
+}
+
+variable "mysql_backup_secret_key" {
+  description = "MySQL backup bucket secret key"
+  type        = string
+  sensitive   = true
+}
+
+variable "mysql_charm_constraints" {
+  # provider sets inconsistent constraint result with architecture (e.g. `arch=amd64`)
+  # user of the module needs to set the variable to the current arch value.
+  # See: https://github.com/juju/terraform-provider-juju/issues/344
+  type    = string
+  default = ""
+}
+
+variable "enable_tls" {
+  type    = bool
+  default = true
+}
+
+variable "s3_integrator_charm_channel" {
+  description = "S3 integrator charm channel"
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "s3_integrator_charm_revision" {
+  description = "S3 integrator charm revision"
+  type        = number
+  default     = 32
+}
+
+variable "s3_integrator_charm_base" {
+  description = "S3 integrator charm base"
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "self_signed_certificates_charm_channel" {
+  description = "Self Signed Certificates Operator charm channel"
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "self_signed_certificates_charm_revision" {
+  description = "Self Signed Operator charm revision"
+  type        = number
+  default     = 155
+}

--- a/modules/machine/mysql-ha/variables.tf
+++ b/modules/machine/mysql-ha/variables.tf
@@ -61,6 +61,12 @@ variable "mysql_charm_constraints" {
   default = ""
 }
 
+variable "mysql_storage_size" {
+  description = "MySQL storage size"
+  type        = string
+  default     = "10G"
+}
+
 variable "enable_tls" {
   type    = bool
   default = true

--- a/modules/machine/mysql-ha/variables.tf
+++ b/modules/machine/mysql-ha/variables.tf
@@ -67,9 +67,57 @@ variable "mysql_storage_size" {
   default     = "10G"
 }
 
+variable "mysql_charm_config" {
+  description = "MySQL charm configuration"
+  type        = map(string)
+  default     = {}
+}
+
+variable "mysql_router_charm_channel" {
+  description = "MySQL router charm channel"
+  type        = string
+  default     = "dpe/edge"
+}
+
+variable "mysql_router_charm_revision" {
+  description = "MySQL router charm revision"
+  type        = number
+  default     = 239
+}
+
+variable "data_integrator_enabled" {
+  description = "Enable data integrator for external connectivity"
+  type        = bool
+  default     = false
+}
+
+variable "data_integrator_charm_channel" {
+  description = "Data integrator charm channel"
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "data_integrator_charm_revision" {
+  description = "Data integrator charm revision"
+  type        = number
+  default     = 41
+}
+
+variable "data_integrator_database_name" {
+  description = "Data integrator database name"
+  type        = string
+  default     = "" # Default to empty string or a reasonable default
+  validation {
+    condition     = var.data_integrator_enabled == false || var.data_integrator_database_name != ""
+    error_message = "data_integrator_database_name must be set if data_integrator_enabled is true."
+  }
+}
+
+
 variable "enable_tls" {
-  type    = bool
-  default = true
+  description = "Enable/enforce TLS through self-signed certificates"
+  type        = bool
+  default     = true
 }
 
 variable "s3_integrator_charm_channel" {

--- a/modules/machine/mysql-ha/versions.tf
+++ b/modules/machine/mysql-ha/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.13.0"
+      version = ">= 0.14.0"
     }
   }
 }

--- a/modules/machine/mysql-ha/versions.tf
+++ b/modules/machine/mysql-ha/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.13.0"
+    }
+  }
+}


### PR DESCRIPTION
### Description

We need to offer HA modules for MySQL k8s and VM as part of 24.10 cycle.

### Type

- [ ] Fix issue <!-- provide the issue number in format #number like #123 -->
- [x] Add module.
- [ ] Change existing module.
- [ ] Other. Please describe bellow.
<!-- Describe type here if you choose Other -->

### How to test
<!-- Provide an example of how to use or test your PR -->

```
cd modules/{k8s,vm}/mysql-ha/
terraform init
terraform apply -var='mysql_charm_constraints=arch=amd64'
```

Var `mysql_charm_constraints` required to workaround [juju provider bug](https://github.com/juju/terraform-provider-juju/issues/344).

All applications should become active and related. Mysql will have `mysql_client` interface offer.

### Additional context
<!-- Provide any additional context that might be relevant -->

I'm aware of current spec to get these modules within projects repo, but until is settled, would like to merge it here.