### PR TITLE
PoC for postgresql-single-vm using PG module

### DIFF
--- a/modules/machine/postgresql-single-vm/main.tf
+++ b/modules/machine/postgresql-single-vm/main.tf
@@ -1,0 +1,21 @@
+resource "juju_machine" "postgresql" {
+  model       = var.juju_model_name
+  base        = var.base
+  name        = var.machine_name
+  constraints = var.machine_constraints
+}
+
+module "postgresql" {
+  juju_model_name  = var.juju_model_name
+  # source           = "../terraform"
+  source           = "github.com/canonical/postgresql-operator//terraform?ref=alutay/update_tf" # TODO: fix branch once PR#1052 is merged
+  app_name         = var.postgresql_app_name
+  channel          = var.postgresql_charm_channel
+  revision         = var.postgresql_charm_revision
+  base             = var.base
+  units            = null
+  machine          = tonumber(juju_machine.postgresql.machine_id)
+  constraints      = var.postgresql_constraints
+  storage          = var.postgresql_storage
+}
+

--- a/modules/machine/postgresql-single-vm/variables.tf
+++ b/modules/machine/postgresql-single-vm/variables.tf
@@ -1,0 +1,53 @@
+variable "juju_model_name" {
+  description = "Juju model name"
+  type        = string
+  nullable    = false
+}
+
+variable "base" {
+  description = "Juju machine and all charms base"
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "machine_name" {
+  description = "Name for the machine resource"
+  type        = string
+  default     = "pg_single_vm"
+}
+
+variable "machine_constraints" {
+  description = "Machine constraints"
+  type        = string
+  default     = ""
+}
+
+variable "postgresql_app_name" {
+  description = "PostgreSQL application name"
+  type        = string
+  default     = "postgresql2"
+}
+
+variable "postgresql_charm_channel" {
+  description = "PostgreSQL charm channel"
+  type        = string
+  default     = "14/stable"
+}
+
+variable "postgresql_charm_revision" {
+  description = "Postgresql charm revision"
+  type        = number
+  default     = null
+}
+
+variable "postgresql_constraints" {
+  description = "Machine constraints"
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "postgresql_storage" {
+  description = "Storage directive"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/machine/postgresql-single-vm/versions.tf
+++ b/modules/machine/postgresql-single-vm/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">=0.20.0"
+    }
+  }
+}


### PR DESCRIPTION
This is a PoC to demonstrate the proper approach of reusing official charmed TF module:
https://github.com/canonical/postgresql-operator/pull/1052

STR:
* juju add-model welcome
* git checkout this pr && cd modules/machine/postgresql-single-vm
* terraform init
* terraform apply -var='juju_model_name=welcome' -auto-approve

Results:
```
Model    Controller  Cloud/Region         Version  SLA          Timestamp
welcome  lxd         localhost/localhost  3.6.8    unsupported  01:56:24+02:00

App          Version  Status  Scale  Charm       Channel    Rev  Exposed  Message
postgresql2  14.15    active      1  postgresql  14/stable  553  yes      

Unit            Workload  Agent  Machine  Public address  Ports     Message
postgresql2/4*  active    idle   29       10.176.3.239    5432/tcp  Primary

Machine  State    Address       Inst id         Base          AZ  Message
29       started  10.176.3.239  juju-4c3f79-29  ubuntu@22.04      Running
```

It is an example to improve PR https://github.com/canonical/terraform-modules/pull/22